### PR TITLE
Add HTML site build (closes #76)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all debug clean daemon manuscript copy-figures flowchart
+.PHONY: all debug clean daemon manuscript copy-figures flowchart site
 
 pandoc_args += -fmarkdown+latex_macros
 pandoc_args += --lua-filter pandoc/hide.lua
@@ -18,7 +18,20 @@ pandoc_latex_args += -s --template latex/template.tex -t latex
 figures_md = $(wildcard md/fig/*)
 figures = $(figures_md:md/%=build/%)
 
+site_pandoc_args += -fmarkdown+latex_macros
+site_pandoc_args += --lua-filter pandoc/html/hide.lua
+site_pandoc_args += --lua-filter pandoc/html/special-divs.lua
+site_pandoc_args += --lua-filter pandoc/fignos.lua
+site_pandoc_args += --lua-filter pandoc/wide_tables.lua
+site_pandoc_args += --lua-filter pandoc/html/numbering.lua
+site_pandoc_args += --citeproc
+site_pandoc_args += --metadata bibliography=md/ref.bib
+site_pandoc_html_args += -s --template html/template.html -t html5
+site_pandoc_html_args += --toc --toc-depth=3 --mathjax --css style.css
+
 all: build/paper.pdf
+
+site: build/site/index.html
 
 manuscript: build/manuscript.pdf build/manuscript.diff.pdf
 
@@ -36,6 +49,12 @@ build/manuscript.tex: md/paper.md
 	@echo "Running pandoc"
 	@mkdir -p $(@D)
 	@pandoc $(pandoc_args) -V manuscript $(pandoc_latex_args) -o $@ $^
+
+build/site/index.html: md/paper.md html/template.html pandoc/html/*.lua
+	@echo "Running pandoc (HTML)"
+	@mkdir -p build/site/fig
+	@pandoc $(site_pandoc_args) $(site_pandoc_html_args) -o $@ $<
+	@cp html/style.css build/site/style.css
 
 build/ref.bib: md/ref.bib
 	@echo "Copying ref.bib"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Use TeXLive &ge; 2023, building with LuaTeX and `latexmk`. On Fedora:
 dnf install texlive-scheme-medium latexmk texlive-selnolig texlive-svg
 ```
 
+### HTML site
+
+Building the HTML version (`make site`) additionally needs `pdftocairo`
+(from `poppler-utils`) to convert PDF figures to SVG. On Fedora:
+
+```bash
+dnf install poppler-utils
+```
+
 ### Entangled
 
 ```bash
@@ -115,6 +124,20 @@ Figure: Depth profile of velocity and shear. The velocity profile was taylored t
 ### Template
 
 We use a modified version of the standard Pandoc template for LaTeX output. The `copernicus` document class and citation styles are shipped in the `latex/copernicus` directory. The template in `latex/template.tex` is configured to use the Geoscientific Model Development (gmd) format. To create a (single column) manuscript version, run `make manuscript`.
+
+## HTML site
+
+Run `make site` to render the paper as a standalone HTML page at `build/site/index.html`, with figures copied into `build/site/fig` (PDF figures are converted to SVG using `pdftocairo`).
+
+The HTML output reuses the format-agnostic filters (`fignos.lua`, `wide_tables.lua`) but needs its own versions of the format-specific ones, kept in `pandoc/html/`:
+
+- `hide.lua` wraps `:::hide` code blocks in a collapsed `<details>` element instead of dropping them, using the `id` or `file` attribute from the code block's YAML header as the summary text.
+- `special-divs.lua` turns divs like `:::abstract`, `:::appendix` or `:::acknowledgements` into headed sections instead of Copernicus LaTeX macros.
+- `numbering.lua` numbers figures, tables, equations and (sub)sections, resolves `@fig:`, `@tbl:`, `@eq:` and `@sec:` references into anchor links, and renders wide figures (`{.wide}`) and wide tables (`:::wide-table`) full width. Appendix sections are numbered with letters (A, B, ...) instead of digits.
+
+Bibliographic citations are resolved with `--citeproc` and `md/ref.bib`, using Pandoc's default citation style (pass `--csl` in the Makefile to use a different one). Equations are rendered with MathJax, loaded from a CDN, so an internet connection is needed to view the equations.
+
+The page layout (`html/template.html`, `html/style.css`) puts the table of contents in a fixed side panel, which collapses behind a menu button on narrow screens.
 
 ## Debugging output
 

--- a/html/style.css
+++ b/html/style.css
@@ -1,0 +1,332 @@
+:root {
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #5a5a5a;
+    --border: #d8d8d8;
+    --nav-bg: #f6f6f4;
+    --link: #0b5fa5;
+    --code-bg: #f2f2ef;
+    --accent: #8a5a00;
+    --nav-width: 280px;
+    --measure: 42em;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #14171a;
+        --fg: #e8e6e1;
+        --muted: #a3a3a3;
+        --border: #33383d;
+        --nav-bg: #1b1f23;
+        --link: #6cb2f0;
+        --code-bg: #1e2226;
+        --accent: #d1a34a;
+    }
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    line-height: 1.6;
+}
+
+a {
+    color: var(--link);
+}
+
+/* Side navigation */
+
+#TOC {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: var(--nav-width);
+    overflow-y: auto;
+    background: var(--nav-bg);
+    border-right: 1px solid var(--border);
+    padding: 1.5rem 1rem;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 0.9rem;
+}
+
+#TOC .toc-title {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.75rem;
+    color: var(--muted);
+    margin-bottom: 0.75rem;
+}
+
+#TOC ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 0.9rem;
+}
+
+#TOC > ul {
+    padding-left: 0;
+}
+
+#TOC li {
+    margin: 0.2rem 0;
+}
+
+#TOC a {
+    color: var(--fg);
+    text-decoration: none;
+    display: block;
+    padding: 0.1rem 0;
+}
+
+#TOC a:hover {
+    color: var(--link);
+    text-decoration: underline;
+}
+
+.nav-toggle {
+    display: none;
+}
+
+.nav-toggle-label {
+    display: none;
+    position: fixed;
+    top: 0.75rem;
+    left: 0.75rem;
+    z-index: 20;
+    background: var(--nav-bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    width: 2.25rem;
+    height: 2.25rem;
+    line-height: 2.25rem;
+    text-align: center;
+    cursor: pointer;
+}
+
+main#content {
+    margin-left: var(--nav-width);
+    padding: 2.5rem clamp(1rem, 4vw, 4rem);
+    max-width: calc(var(--measure) + 4rem);
+}
+
+@media (max-width: 900px) {
+    #TOC {
+        transform: translateX(-100%);
+        transition: transform 0.2s ease-in-out;
+        z-index: 15;
+        box-shadow: 2px 0 12px rgba(0, 0, 0, 0.2);
+    }
+
+    .nav-toggle:checked ~ #TOC {
+        transform: translateX(0);
+    }
+
+    .nav-toggle-label {
+        display: block;
+    }
+
+    main#content {
+        margin-left: 0;
+        padding-top: 4rem;
+    }
+}
+
+/* Title block */
+
+#title-block-header {
+    margin-bottom: 2.5rem;
+}
+
+#title-block-header .title {
+    font-size: 1.9rem;
+    margin-bottom: 0.25rem;
+}
+
+#title-block-header .subtitle {
+    display: block;
+    font-size: 1.2rem;
+    font-weight: 400;
+    color: var(--muted);
+}
+
+#title-block-header .author {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+#title-block-header .affiliations {
+    color: var(--muted);
+    font-size: 0.85rem;
+    padding-left: 1.2rem;
+}
+
+/* Headings */
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    line-height: 1.25;
+    scroll-margin-top: 1.5rem;
+}
+
+.secnum {
+    color: var(--accent);
+    margin-right: 0.5em;
+}
+
+/* Figures */
+
+.figure {
+    margin: 2rem 0;
+    text-align: center;
+}
+
+.figure img {
+    max-width: 100%;
+    height: auto;
+}
+
+.figure.wide {
+    max-width: none;
+    margin-left: calc(-1 * clamp(0px, (100% - var(--measure)) / 2, 8rem));
+    margin-right: calc(-1 * clamp(0px, (100% - var(--measure)) / 2, 8rem));
+}
+
+.figure p {
+    font-size: 0.9rem;
+    color: var(--muted);
+    text-align: left;
+    margin-top: 0.5rem;
+}
+
+.fig-number,
+.tbl-number {
+    font-weight: 600;
+    color: var(--fg);
+}
+
+/* Tables */
+
+table {
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    font-size: 0.9rem;
+}
+
+table.wide-table {
+    width: 100%;
+}
+
+caption {
+    caption-side: bottom;
+    text-align: left;
+    font-size: 0.9rem;
+    color: var(--muted);
+    margin-top: 0.5rem;
+}
+
+th, td {
+    border: 1px solid var(--border);
+    padding: 0.4rem 0.7rem;
+    text-align: left;
+}
+
+th {
+    background: var(--code-bg);
+}
+
+/* Equations */
+
+.equation {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 1.5rem 0;
+    scroll-margin-top: 1.5rem;
+}
+
+.eq-body {
+    overflow-x: auto;
+    flex: 1;
+}
+
+.eq-number {
+    color: var(--muted);
+    padding-left: 1rem;
+    white-space: nowrap;
+}
+
+/* Code */
+
+pre, code {
+    font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 0.85em;
+}
+
+pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.85rem 1rem;
+    overflow-x: auto;
+}
+
+code {
+    background: var(--code-bg);
+    border-radius: 3px;
+    padding: 0.1em 0.3em;
+}
+
+pre code {
+    background: none;
+    padding: 0;
+}
+
+details.hide-code {
+    margin: 1.25rem 0;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.85rem;
+}
+
+details.hide-code summary {
+    cursor: pointer;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: var(--muted);
+}
+
+details.hide-code[open] summary {
+    margin-bottom: 0.5rem;
+}
+
+/* Special sections */
+
+.abstract, .code-availability, .appendix, .author-contribution,
+.competing-interests, .acknowledgements, .disclaimer {
+    margin: 2rem 0;
+}
+
+.abstract {
+    font-size: 0.95rem;
+    color: var(--muted);
+    border-left: 3px solid var(--border);
+    padding-left: 1rem;
+}
+
+blockquote {
+    border-left: 3px solid var(--border);
+    margin-left: 0;
+    padding-left: 1rem;
+    color: var(--muted);
+}

--- a/html/template.html
+++ b/html/template.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+$for(author-meta)$
+  <meta name="author" content="$author-meta$" />
+$endfor$
+$if(description-meta)$
+  <meta name="description" content="$description-meta$" />
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+$for(css)$
+  <link rel="stylesheet" href="$css$" />
+$endfor$
+$for(header-includes)$
+  $header-includes$
+$endfor$
+$if(math)$
+  $math$
+$endif$
+</head>
+<body>
+  <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+  <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
+$if(toc)$
+  <nav id="TOC" role="doc-toc">
+    <div class="toc-title">Contents</div>
+$table-of-contents$
+  </nav>
+$endif$
+  <main id="content">
+$if(title)$
+    <header id="title-block-header">
+      <h1 class="title">$title$$if(subtitle)$<br /><span class="subtitle">$subtitle$</span>$endif$</h1>
+$if(author)$
+      <p class="author">
+$for(author)$
+        <span class="author-name">$author.given_name$ $author.surname$$if(author.affiliation)$<sup>$author.affiliation$</sup>$endif$</span>$sep$, $endfor$
+      </p>
+$endif$
+$if(affiliation)$
+      <ol class="affiliations">
+$for(affiliation/pairs)$
+        <li value="$affiliation.key$">$affiliation.value$</li>
+$endfor$
+      </ol>
+$endif$
+    </header>
+$endif$
+$body$
+  </main>
+</body>
+</html>

--- a/html/template.html
+++ b/html/template.html
@@ -22,6 +22,7 @@ $if(math)$
 $endif$
 </head>
 <body>
+  <span class="math display">\[\newcommand{unit}[1]{{\rm #1}}\]</span>
   <input type="checkbox" id="nav-toggle" class="nav-toggle" />
   <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
 $if(toc)$

--- a/pandoc/html/hide.lua
+++ b/pandoc/html/hide.lua
@@ -1,0 +1,53 @@
+--- For HTML output, code blocks marked with the `hide` class are not
+--- dropped (as they are for LaTeX/PDF output), but wrapped in a
+--- collapsed `<details>` element instead, so readers can still open and
+--- inspect the source. The `<summary>` text is taken from the `id` or
+--- `file` attribute found in the first code block's YAML header.
+
+local function escape_html(s)
+    return (s:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;"))
+end
+
+local function find_label(code_text)
+    for line in code_text:gmatch("[^\r\n]+") do
+        local id = line:match("^#|%s*id:%s*(.-)%s*$")
+        if id then
+            return id
+        end
+    end
+    for line in code_text:gmatch("[^\r\n]+") do
+        local file = line:match("^#|%s*file:%s*(.-)%s*$")
+        if file then
+            return (file:gsub('^"(.*)"$', "%1"))
+        end
+    end
+    return nil
+end
+
+local function first_label(blocks)
+    for _, b in ipairs(blocks) do
+        if b.t == "CodeBlock" then
+            local label = find_label(b.text)
+            if label then
+                return label
+            end
+        end
+    end
+    return nil
+end
+
+function Div(el)
+    if el.classes[1] ~= "hide" then
+        return
+    end
+
+    local label = first_label(el.content) or "code"
+    local out = pandoc.List()
+    out:insert(pandoc.RawBlock("html",
+        "<details class=\"hide-code\"><summary><code>" .. escape_html(label) .. "</code></summary>"))
+    for _, b in ipairs(el.content) do
+        out:insert(b)
+    end
+    out:insert(pandoc.RawBlock("html", "</details>"))
+    return out
+end

--- a/pandoc/html/numbering.lua
+++ b/pandoc/html/numbering.lua
@@ -1,0 +1,291 @@
+--- HTML equivalent of `fignos.lua` + `figref.lua` + `eqnos.lua` +
+--- `wide_figures.lua` + `plain_tables.lua`. Where the LaTeX filters lean
+--- on LaTeX's own `\ref`/`\label`/counter machinery, here we have to do
+--- the figure/table/equation/section numbering and cross-referencing by
+--- hand, and copy (and where needed convert) the referenced figures into
+--- the site's `fig/` directory.
+---
+--- Assumes `fignos.lua` and `wide_tables.lua` have already run, so that
+--- Figure blocks carry their final `fig:...` identifier and caption, and
+--- wide tables already carry the `wide-table` class.
+
+local site_dir = "build/site"
+local fig_dir = site_dir .. "/fig"
+
+local fig_count = 0
+local fig_ids = {}
+local tbl_count = 0
+local tbl_ids = {}
+local eq_count = 0
+local eq_ids = {}
+local sec_ids = {}
+
+local sec_counters = { 0, 0, 0, 0, 0, 0 }
+local appendix_counters = { 0, 0, 0, 0, 0, 0 }
+
+local mkdir_done = false
+local function ensure_fig_dir()
+    if not mkdir_done then
+        os.execute("mkdir -p \"" .. fig_dir .. "\"")
+        mkdir_done = true
+    end
+end
+
+--- Copies (and converts PDF to SVG) a figure source into build/site/fig,
+--- returning the path relative to the generated HTML file.
+local function copy_or_convert_image(src)
+    local full_src = pandoc.path.join { "md", src }
+    local base = pandoc.path.filename(src)
+    local name, ext = pandoc.path.split_extension(base)
+    ensure_fig_dir()
+    if ext == ".pdf" then
+        local target_rel = pandoc.path.join { "fig", name .. ".svg" }
+        local target = pandoc.path.join { site_dir, target_rel }
+        local ok = os.execute("pdftocairo -svg \"" .. full_src .. "\" \"" .. target .. "\"")
+        if not ok then
+            io.stderr:write("WARNING: could not convert " .. full_src ..
+                " to SVG (is poppler-utils/pdftocairo installed?)\n")
+        end
+        return target_rel
+    else
+        local target_rel = pandoc.path.join { "fig", base }
+        local target = pandoc.path.join { site_dir, target_rel }
+        os.execute("cp \"" .. full_src .. "\" \"" .. target .. "\"")
+        return target_rel
+    end
+end
+
+--- Strips a trailing `{#tag}` from the last inline of a caption's first
+--- block, returning the tag (or nil).
+local function extract_tag(caption_long, pattern)
+    if not caption_long or not caption_long[1] or not caption_long[1].content then
+        return nil
+    end
+    local content = caption_long[1].content
+    local last = content[#content]
+    if not last or not last.text then
+        return nil
+    end
+    local tag = string.match(last.text, pattern)
+    if tag then
+        table.remove(content, #content)
+        -- drop a trailing space left behind, if any
+        local new_last = content[#content]
+        if new_last and new_last.t == "Space" then
+            table.remove(content, #content)
+        end
+    end
+    return tag
+end
+
+local function flatten_inlines(blocks)
+    local out = pandoc.List()
+    for _, blk in ipairs(blocks or {}) do
+        if blk.content then
+            for _, inl in ipairs(blk.content) do
+                out:insert(inl)
+            end
+        end
+    end
+    return out
+end
+
+local function process_figure(el)
+    local plain = el.content[1]
+    local img = plain and plain.content and plain.content[1]
+    if not img or img.t ~= "Image" then
+        return el
+    end
+
+    fig_count = fig_count + 1
+    if el.identifier ~= "" then
+        fig_ids[el.identifier] = fig_count
+    end
+
+    local target_rel = copy_or_convert_image(img.src)
+    local is_wide = img.classes:includes("wide")
+
+    local new_img = pandoc.Image(img.caption, target_rel, img.title, pandoc.Attr("", {}, {}))
+
+    local caption_inlines = flatten_inlines(el.caption.long)
+    local number_span = pandoc.Span({ pandoc.Str("Figure " .. fig_count .. ": ") },
+        pandoc.Attr("", { "fig-number" }))
+    local caption_content = pandoc.List { number_span }
+    caption_content:extend(caption_inlines)
+
+    local classes = { "figure" }
+    if is_wide then
+        table.insert(classes, "wide")
+    end
+
+    return pandoc.Div({
+        pandoc.Plain { new_img },
+        pandoc.Para(caption_content),
+    }, pandoc.Attr(el.identifier, classes))
+end
+
+local function process_table(el)
+    local tag = extract_tag(el.caption.long, "{#(tbl:[%w%-_]+)}")
+    if tag then
+        el.identifier = tag
+    end
+    tbl_count = tbl_count + 1
+    if el.identifier ~= "" then
+        tbl_ids[el.identifier] = tbl_count
+    end
+
+    local number_span = pandoc.Span({ pandoc.Str("Table " .. tbl_count .. ": ") },
+        pandoc.Attr("", { "tbl-number" }))
+    local caption_inlines = flatten_inlines(el.caption.long)
+    local caption_content = pandoc.List { number_span }
+    caption_content:extend(caption_inlines)
+    el.caption.long = { pandoc.Plain(caption_content) }
+    return el
+end
+
+local function letter(n)
+    return string.char(64 + n)
+end
+
+local function number_header(el, in_appendix)
+    if el.classes:includes("unnumbered") then
+        return el
+    end
+
+    local counters = in_appendix and appendix_counters or sec_counters
+    local lvl = math.min(el.level, #counters)
+    counters[lvl] = counters[lvl] + 1
+    for i = lvl + 1, #counters do
+        counters[i] = 0
+    end
+
+    local parts = {}
+    for i = 1, lvl do
+        if counters[i] > 0 then
+            if in_appendix and i == 1 then
+                table.insert(parts, letter(counters[i]))
+            else
+                table.insert(parts, tostring(counters[i]))
+            end
+        end
+    end
+    local label = table.concat(parts, ".")
+    if el.identifier ~= "" then
+        sec_ids[el.identifier] = label
+    end
+
+    table.insert(el.content, 1, pandoc.Space())
+    table.insert(el.content, 1, pandoc.Span({ pandoc.Str(label) }, pandoc.Attr("", { "secnum" })))
+    return el
+end
+
+--- Detects a display equation immediately followed by `{#eq:...}`,
+--- i.e. the pattern produced by `$$...$$${#eq:tag}` in the markdown
+--- source, and numbers it.
+local function process_para(el)
+    local content = el.content
+    for i, inl in ipairs(content) do
+        if inl.t == "Math" and inl.mathtype == "DisplayMath" then
+            local nxt = content[i + 1]
+            if nxt and nxt.t == "Str" then
+                local tag = string.match(nxt.text, "^{#(eq:[%w%-_]+)}$")
+                if tag then
+                    eq_count = eq_count + 1
+                    eq_ids[tag] = eq_count
+                    return pandoc.Div({
+                        pandoc.Plain {
+                            pandoc.Span({ inl }, pandoc.Attr("", { "eq-body" })),
+                            pandoc.Span({ pandoc.Str("(" .. eq_count .. ")") }, pandoc.Attr("", { "eq-number" })),
+                        },
+                    }, pandoc.Attr(tag, { "equation" }))
+                end
+            end
+        end
+    end
+    return el
+end
+
+local process_blocks
+
+local function process_div(el, in_appendix)
+    local cls = {}
+    for _, c in ipairs(el.classes) do
+        cls[c] = true
+    end
+    local inner_appendix = in_appendix or cls["appendix"]
+    local content = process_blocks(el.content, inner_appendix)
+    if cls["wide-table"] then
+        -- the table itself already carries the wide-table class (set by
+        -- wide_tables.lua), so the wrapping div is redundant for HTML
+        return content
+    end
+    el.content = content
+    return el
+end
+
+process_blocks = function(blocks, in_appendix)
+    local out = pandoc.List()
+    for _, el in ipairs(blocks) do
+        if el.t == "Div" then
+            local result = process_div(el, in_appendix)
+            if result.t then
+                out:insert(result)
+            else
+                out:extend(result)
+            end
+        elseif el.t == "Header" then
+            out:insert(number_header(el, in_appendix))
+        elseif el.t == "Figure" then
+            out:insert(process_figure(el))
+        elseif el.t == "Table" then
+            out:insert(process_table(el))
+        elseif el.t == "Para" then
+            out:insert(process_para(el))
+        else
+            out:insert(el)
+        end
+    end
+    return out
+end
+
+local function label_for(id)
+    if fig_ids[id] then
+        return tostring(fig_ids[id])
+    end
+    if tbl_ids[id] then
+        return tostring(tbl_ids[id])
+    end
+    if eq_ids[id] then
+        return tostring(eq_ids[id])
+    end
+    if sec_ids[id] then
+        return sec_ids[id]
+    end
+    return nil
+end
+
+local function resolve_cite(el)
+    if #el.citations ~= 1 then
+        return nil
+    end
+    local id = el.citations[1].id
+    local label = label_for(id)
+    if not label then
+        return nil
+    end
+
+    local plain_ref = pandoc.write(pandoc.Pandoc { table.unpack(el.content) }, "plain")
+    local pre = string.match(plain_ref, "%[([^@]*)@.*%]")
+    local text
+    if pre then
+        text = (pre:gsub("%s+$", "")) .. " " .. label
+    else
+        text = label
+    end
+    return pandoc.Link({ pandoc.Str(text) }, "#" .. id)
+end
+
+function Pandoc(doc)
+    doc.blocks = process_blocks(doc.blocks, false)
+    return doc:walk { Cite = resolve_cite }
+end

--- a/pandoc/html/special-divs.lua
+++ b/pandoc/html/special-divs.lua
@@ -1,0 +1,40 @@
+--- HTML equivalent of `special-divs.lua`. Instead of wrapping content in
+--- LaTeX/Copernicus macros, we prepend an (unnumbered) heading so the
+--- section reads sensibly in the HTML output. The original class is kept
+--- on the div so it can be styled through CSS, and so that `numbering.lua`
+--- can still recognise the `appendix` div further down the filter chain.
+
+function Div(el)
+    local cls = {}
+    for _, c in ipairs(el.classes) do
+        cls[c] = true
+    end
+
+    local function with_heading(level, text)
+        local heading = pandoc.Header(level, { pandoc.Str(text) }, pandoc.Attr("", { "unnumbered" }))
+        table.insert(el.content, 1, heading)
+        return el
+    end
+
+    if cls["abstract"] then
+        return with_heading(2, "Abstract")
+    end
+    if cls["code-availability"] then
+        return with_heading(2, "Code and Data Availability")
+    end
+    if cls["appendix"] then
+        return with_heading(1, "Appendix")
+    end
+    if cls["author-contribution"] then
+        return with_heading(2, "Author Contributions")
+    end
+    if cls["competing-interests"] then
+        return with_heading(2, "Competing Interests")
+    end
+    if cls["acknowledgements"] then
+        return with_heading(2, "Acknowledgements")
+    end
+    if cls["disclaimer"] then
+        return with_heading(2, "Disclaimer")
+    end
+end


### PR DESCRIPTION
This is an unreviewed draft version.

Introduces `make site`, rendering md/paper.md to a standalone HTML page at build/site/index.html via Pandoc. The LaTeX/PDF pipeline is untouched.

- pandoc/html/hide.lua wraps `:::hide` code blocks in collapsed <details> elements instead of dropping them, labelled from the code block's `id` or `file` attribute.
- pandoc/html/special-divs.lua turns abstract/appendix/acknowledgements/etc. divs into headed sections instead of Copernicus LaTeX macros.
- pandoc/html/numbering.lua numbers figures, tables, equations and (sub)sections by hand, resolves @fig:/@tbl:/@eq:/@sec: references into anchor links, renders wide figures/tables full width, copies figures into build/site/fig (converting PDF to SVG via pdftocairo), and letters appendix sections (A, B, ...). The format-agnostic fignos.lua and wide_tables.lua filters are reused unchanged.
- html/template.html and html/style.css lay out the page with a fixed side panel for table-of-contents navigation, collapsing to a menu button on narrow screens.

Bibliographic citations go through --citeproc against md/ref.bib, and equations are rendered client-side via MathJax.